### PR TITLE
FIX: colorbar [...] interpolation nearest

### DIFF
--- a/src/gle/bitmap/img2ps.cpp
+++ b/src/gle/bitmap/img2ps.cpp
@@ -639,7 +639,10 @@ NearestIpol::NearestIpol(IpolData* data):
 }
 
 double NearestIpol::ipol(double xp, double yp) {
-	return m_Data->getValue(gle_round_int(xp * m_Data->getWidth()), gle_round_int(yp * m_Data->getHeight()));
+	return m_Data->getValue(
+		(int)floor(xp * m_Data->getWidth()), // gle_round_int(xp * m_Data->getWidth())
+		(int)floor(yp * m_Data->getHeight()) // gle_round_int(yp * m_Data->getHeight())
+	);
 }
 
 void GLEBitmapSetPalette(GLEBYTE* pal, int offs, double red, double green, double blue) {


### PR DESCRIPTION
Fixes issue with interpolation routine ```nearest``` of command ```colormap```.
See following code printing [0.5, 1, 1] instead of expected [0, 0.5, 1]:
```
size 10 2

sub my_palette z
	print "Z-Value: " z
	return rgb(z, 0, 0)
end sub

begin letz
	! will create file aux.z:
	! ! nx 3 ny 1 xmin 0 xmax 2 ymin 0 ymax 1
	! 0 0.5 1
	data "aux.z"
	z = x/2
	x from 0 to 2 step 1
	y from 0 to 1 step 2
end letz

begin graph
	scale auto
	yaxis off
	colormap "aux.z" 3 1 zmin 0 zmax 1 palette my_palette interpolate nearest
end graph
```