### PR TITLE
FIX: math ** power operator (regression)

### DIFF
--- a/src/gle/polish.cpp
+++ b/src/gle/polish.cpp
@@ -88,6 +88,7 @@ void GLEPolish::initTokenizer() {
 	lang->addLanguageElem(0, "<=");
 	lang->addLanguageElem(0, ">=");
 	lang->addLanguageElem(0, "<>");
+	lang->addLanguageElem(0, "**");
 	// -- additions for shortcut operators (also see pass.cpp)
 	lang->addLanguageElem(0, "+=");
 	lang->addLanguageElem(0, "-=");


### PR DESCRIPTION
Math power operator ** was removed via commit https://github.com/vlabella/GLE/commit/f4a28fe9abd9ceebfdea4ee9cf6e0dfece11c6a7 (without cleaning the rest of the codebase).
This commit put it back, so GLE scripts using this syntax works as before.